### PR TITLE
Use raw string for regex

### DIFF
--- a/python3/diff_match_patch.py
+++ b/python3/diff_match_patch.py
@@ -1804,7 +1804,7 @@ class diff_match_patch:
       return patches
     text = textline.split('\n')
     while len(text) != 0:
-      m = re.match("^@@ -(\d+),?(\d*) \+(\d+),?(\d*) @@$", text[0])
+      m = re.match(r"^@@ -(\d+),?(\d*) \+(\d+),?(\d*) @@$", text[0])
       if not m:
         raise ValueError("Invalid patch string: " + text[0])
       patch = patch_obj()


### PR DESCRIPTION
Prevents warnings being emitted with recent python versions.

For example, with Python 3.7:

> diff_match_patch/diff_match_patch.py:1807: DeprecationWarning: invalid escape sequence \d
    m = re.match("^@@ -(\d+),?(\d*) \+(\d+),?(\d*) @@$", text[0])

