### PR TITLE
Fix lineHash.hasOwnProperty might be contaminated

### DIFF
--- a/javascript/diff_match_patch_uncompressed.js
+++ b/javascript/diff_match_patch_uncompressed.js
@@ -495,7 +495,7 @@ diff_match_patch.prototype.diff_linesToChars_ = function(text1, text2) {
       }
       var line = text.substring(lineStart, lineEnd + 1);
 
-      if (lineHash.hasOwnProperty ? lineHash.hasOwnProperty(line) :
+      if (lineHash.hasOwnProperty ? Object.prototype.hasOwnProperty.call(lineHash, line) :
           (lineHash[line] !== undefined)) {
         chars += String.fromCharCode(lineHash[line]);
       } else {


### PR DESCRIPTION
if calling method like `dmp.diff_linesToChars_('hasOwnProperty', ' ')` will throw `TypeError: lineHash.hasOwnProperty is not a function`
since the lineHash is a instance of Object, the method can be overwritten while walking through the text lines.

To avoid this, we can use `Object.prototype.hasOwnProperty.call(lineHash, line)` that make it always can call hasOwnProperty properly.

See more at: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty