### PR TITLE
[JavaScript] diff_prettyHtml highlight leading/trailing space difference

### DIFF
--- a/javascript/diff_match_patch_uncompressed.js
+++ b/javascript/diff_match_patch_uncompressed.js
@@ -1254,11 +1254,17 @@ diff_match_patch.prototype.diff_prettyHtml = function(diffs) {
   var pattern_lt = /</g;
   var pattern_gt = />/g;
   var pattern_para = /\n/g;
+  var pattern_space = /^ | $/g;
+
   for (var x = 0; x < diffs.length; x++) {
     var op = diffs[x][0];    // Operation (insert, delete, equal)
     var data = diffs[x][1];  // Text of change.
-    var text = data.replace(pattern_amp, '&amp;').replace(pattern_lt, '&lt;')
-        .replace(pattern_gt, '&gt;').replace(pattern_para, '&para;<br>');
+    var text = data
+      .replace(pattern_amp, '&amp;')
+      .replace(pattern_lt, '&lt;')
+      .replace(pattern_gt, '&gt;')
+      .replace(pattern_para, '&para;<br>')
+      .replace(pattern_space, '&nbsp;');
     switch (op) {
       case DIFF_INSERT:
         html[x] = '<ins style="background:#e6ffe6;">' + text + '</ins>';


### PR DESCRIPTION
`diff_prettyHtml` currently doesn't highlight leading/trailing space differences. Because spaces in HTML aren't visible.

This pull request changes that.

Instead of
```html
<ins style="background:#e6ffe6;"> </ins>
``` 
`diff_prettyHtml` now returns
```html
<ins style="background:#e6ffe6;">&nbsp;</ins>
```
resulting in differences with leading/training spaces being visible in HTML.

---


**Example:**
When we compare `Test` and `Test ` (notice the second string doesn't equal the first string since it has a trailing space). 
```JavaScript
var diff = dmp.diff_main("Test", "Test "); // this results in the following diff: [[0, 'Test'], [1, ' ']]
```
Previously looked like this:
![image](https://github.com/google/diff-match-patch/assets/17022670/5ebd2764-0129-49f0-b3c0-ec77319316f3)

Now with this pull requests it looks like this:
![image](https://github.com/google/diff-match-patch/assets/17022670/f99add6a-79c2-42f5-8286-fa043903b9f5)



