### PR TITLE
Fix memory leak in Patch in Objective-C version

### DIFF
--- a/objectivec/DiffMatchPatch.m
+++ b/objectivec/DiffMatchPatch.m
@@ -189,7 +189,7 @@ void splice(NSMutableArray *input, NSUInteger start, NSUInteger count, NSArray *
 {
   Patch *newPatch = [[[self class] allocWithZone:zone] init];
 
-  newPatch.diffs = [[NSMutableArray alloc] initWithArray:self.diffs copyItems:YES];
+  newPatch.diffs = [[[NSMutableArray alloc] initWithArray:self.diffs copyItems:YES] autorelease];
   newPatch.start1 = self.start1;
   newPatch.start2 = self.start2;
   newPatch.length1 = self.length1;


### PR DESCRIPTION
The `NSMutableArray` being assigned to `Patch.diffs` isn't being autoreleased correctly. Since it's being assigned to a synthesized property marked with retain, and the `NSMutableArray` is being initialized with alloc-init, the array needs to be autoreleased so that it doesn't leak.